### PR TITLE
Retrieve arrivals by StopId.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,16 @@ var clientSettings = new ClientSettings { ServerRootUrl = "http://example.com/" 
 IMetroApiClient client = new MetroApiClient(clientSettings);
 ```
 
-### Retrieving arrivals per node
+### Retrieving arrival times
 
-With a known Node ID, you can retrieve upcoming arrivals at that particular Node:
+With a known Node or Stop ID, you can retrieve upcoming arrivals at that particular Node or Stop:
 
 ```csharp
 string nodeId = "11130-MB";
-var arrivals = client.GetNodeTimes(nodeId);
+var nodeArrivals = client.GetNodeTimes(nodeId);
+
+string stopId = "30002";
+var stopArrivals = client.GetStopTimes(stopId);
 ```
 
 ### Stop and route discovery

--- a/src/Syncromatics.Clients.Metro.Api/IMetroApiClient.cs
+++ b/src/Syncromatics.Clients.Metro.Api/IMetroApiClient.cs
@@ -17,6 +17,13 @@ namespace Syncromatics.Clients.Metro.Api
         Task<List<NodeTime>> GetNodeTimes(string nodeId);
 
         /// <summary>
+        /// Get arrival times for a Metro stop
+        /// </summary>
+        /// <param name="stopId">ID of the Metro stop</param>
+        /// <returns>List of arrival times fo rthe given <param name="stopId"/></returns>
+        Task<List<NodeTime>> GetStopTimes(string stopId);
+
+        /// <summary>
         /// Gets a list of stops for a Metro node
         /// </summary>
         /// <param name="nodeId">ID of the Metro node.  May optionally include corner in the format NODEID-CORNER, e.g. 1234-NE.</param>

--- a/src/Syncromatics.Clients.Metro.Api/MetroApiClient.cs
+++ b/src/Syncromatics.Clients.Metro.Api/MetroApiClient.cs
@@ -20,6 +20,15 @@ namespace Syncromatics.Clients.Metro.Api
             return response.NodeTimes;
         }
 
+        public async Task<List<NodeTime>> GetStopTimes(string stopId)
+        {
+            var response = await ExecuteAsync<NodeTimesResponse>(new MetroJsonRequest("/api/node_time.php", Method.GET)
+                .AddQueryParameter("stop_id", stopId)
+                .AddQueryParameter("format", "json"));
+
+            return response.NodeTimes;
+        }
+
         public async Task<List<Stop>> GetStopsByNodeId(string nodeId, string corner = null)
         {
             var request = new MetroJsonRequest("/API/=stops_SYNC/Stops_N_Node.php", Method.GET)

--- a/tests/Syncromatics.Clients.Metro.Api.Tests/Integration/When_requesting_data_from_the_MTA_Trip_API.cs
+++ b/tests/Syncromatics.Clients.Metro.Api.Tests/Integration/When_requesting_data_from_the_MTA_Trip_API.cs
@@ -22,13 +22,26 @@ namespace Syncromatics.Clients.Metro.Api.Tests.Integration
         [InlineData("11130-MB")]
         [InlineData("11130")]
         [InlineData("11131")]
-        public async void It_should_get_times_for_a_known_node(string nodeId)
+        public async void It_should_get_times_for_a_known_node_id(string nodeId)
         {
             var times = await _subject.GetNodeTimes(nodeId);
 
             times.Should().NotBeNull();
             times.Should().NotBeEmpty();
             times.Select(nt => nt.CarrierName.ToLower()).Should().IntersectWith(new[] { "metro" });
+        }
+
+        [Theory]
+        [InlineData("30002")]
+        [InlineData("12530")]
+        [InlineData("9333")]
+        public async void It_should_get_times_for_a_known_stop_id(string stopId)
+        {
+            var times = await _subject.GetStopTimes(stopId);
+
+            times.Should().NotBeNull();
+            times.Should().NotBeEmpty();
+            times.Select(st => st.CarrierName.ToLower()).Should().IntersectWith(new[] {"metro"});
         }
 
         [Theory]


### PR DESCRIPTION
Add ability to query `node_times.php` endpoint by `stopId` rather than `nodeId`.  Update readme, add tests.