### PR TITLE
Parse RouteId from Node Time response.

### DIFF
--- a/src/Syncromatics.Clients.Metro.Api/Models/NodeTime.cs
+++ b/src/Syncromatics.Clients.Metro.Api/Models/NodeTime.cs
@@ -16,6 +16,8 @@ namespace Syncromatics.Clients.Metro.Api.Models
         public string Direction { get; set; }
         public string Location { get; set; }
         public string Bay { get; set; }
+        [JsonProperty("route_identifier")]
+        public string RouteId { get; set; }
         [JsonProperty("stop_id")]
         public string StopId { get; set; }
         public string Times { get; set; }


### PR DESCRIPTION
There might be another related pull request in a few days, Metro is considering renaming this parameter from `route_identifier` to `route_id`.